### PR TITLE
Implement parallel rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.1.0"
 dependencies = [
  "cgmath 0.12.0 (git+https://github.com/Mange/cgmath?branch=serde-09)",
  "image 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/raingun-lib/Cargo.toml
+++ b/raingun-lib/Cargo.toml
@@ -6,5 +6,6 @@ authors = ["Magnus Bergmark <magnus.bergmark@gmail.com>"]
 [dependencies]
 cgmath = { git = "https://github.com/Mange/cgmath", branch = "serde-09", default-features = false, features = ["eders"] }
 image = "0.12"
+rayon = "0.6"
 serde = "0.9"
 serde_derive = "0.9"

--- a/raingun-lib/src/lib.rs
+++ b/raingun-lib/src/lib.rs
@@ -1,9 +1,11 @@
-extern crate image;
 extern crate cgmath;
-
+extern crate image;
+extern crate rayon;
 extern crate serde;
+
 #[macro_use]
 extern crate serde_derive;
+
 
 // TODO: Make this an attribute of the scene
 const SHADOW_BIAS: f64 = 1e-13;


### PR DESCRIPTION
This fixes #8.

With this algorithm in place, I got a much faster render time on my workstation (4 threads).

Here's the results, when I had both implementations present in the code:

## Original implementation

```bash
./target/release/raingun -w 4096 -h 2660 -o 4k-test.jpg examples/test1.yml
```

\# | Render time | Write time
---|-------------|-----------
 1 |       6.19s |      318ms
 2 |       6.20s |      318ms
 3 |       6.23s |      326ms
 4 |       6.16s |      321ms

## Parallel implementation

```bash
PAR=1 ./target/release/raingun -w 4096 -h 2660 -o 4k-test.jpg examples/test1.yml
```

\# | Render time | Write time
---|-------------|-----------
 1 |       1.23s |      319ms
 2 |       1.23s |      319ms
 3 |       1.23s |      319ms
 4 |       1.25s |      318ms

## Conclusions

* The sequential rendering is almost 5 times slower.
* Output image is byte-identical in both cases.