### PR TITLE
Preview window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,11 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "android_glue"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ansi_term"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23,6 +28,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "approx"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "arrayvec"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "atty"
@@ -36,6 +50,16 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -45,9 +69,28 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cgl"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gleam 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cgmath"
@@ -77,9 +120,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "cocoa"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cocoa"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "core-foundation"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "deflate"
@@ -99,11 +202,97 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libloading 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "draw_state"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dtoa"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "dwmapi-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "enum_primitive"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fs2"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gdi32-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gfx"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "draw_state 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx_core 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gfx_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "draw_state 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gfx_device_gl"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gfx_core 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx_gl 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gfx_gl"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gl_generator 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -116,9 +305,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gl_generator 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gl_generator"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "khronos_api 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gleam"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gl_generator 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "glutin"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "android_glue 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cgl 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dwmapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gdi32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gl_generator 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shared_library 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shell32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11-dl 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "image"
@@ -143,6 +386,16 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "interpolation"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "itoa"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "jpeg-decoder"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,8 +414,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "khronos_api"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libloading"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target_build_utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -171,9 +450,41 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "log"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "lzw"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memmap"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fs2 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nodrop"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "num-integer"
@@ -215,6 +526,192 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "odds"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "osmesa-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "shared_library 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf"
+version = "0.7.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.7.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_generator 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.7.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.7.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "piston"
+version = "0.31.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pistoncore-event_loop 0.31.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-input 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-window 0.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "piston-float"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "piston-gfx_texture"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gfx 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx_core 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston-texture 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "piston-shaders_graphics2d"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "piston-texture"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "piston-viewport"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "piston-float 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "piston2d-gfx_graphics"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "draw_state 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston-gfx_texture 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston-shaders_graphics2d 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston2d-graphics 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusttype 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shader_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "piston2d-graphics"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "interpolation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston-texture 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston-viewport 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "read_color 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vecmath 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "piston_window"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gfx 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx_device_gl 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston 0.31.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston-texture 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston2d-gfx_graphics 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston2d-graphics 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-glutin_window 0.35.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shader_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pistoncore-event_loop"
+version = "0.31.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "piston-viewport 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-input 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-window 0.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pistoncore-glutin_window"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gl 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glutin 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-input 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-window 0.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shader_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pistoncore-input"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston-viewport 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pistoncore-window"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pistoncore-input 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shader_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "png"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +733,7 @@ version = "0.1.0"
 dependencies = [
  "clap 2.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "piston_window 0.64.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "raingun-lib 0.1.0",
  "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -263,13 +761,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "read_color"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rustc-serialize"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc_version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rusttype"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stb_truetype 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "scoped_threadpool"
 version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "semver"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -296,6 +837,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +855,42 @@ dependencies = [
  "linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "shader_version"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "shared_library"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "shell32-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "siphasher"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "stb_truetype"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -326,6 +914,28 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "target_build_utils"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_codegen 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempfile"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -365,9 +975,76 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "user32-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "vec_map"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vecmath"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "piston-float 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-scanner 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wayland-kbd"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dlib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "xml-rs 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dlib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wayland-window"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi"
@@ -380,6 +1057,50 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winit"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "android_glue 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cgl 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dwmapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gdi32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shared_library 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shell32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-kbd 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-window 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11-dl 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "x11-dl"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,51 +1110,134 @@ dependencies = [
 
 [metadata]
 "checksum adler32 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ff33fe13a08dbce05bcefa2c68eea4844941437e33d6f808240b54d7157b9cd"
+"checksum android_glue 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d8289e9637439939cc92b1995b0972117905be88bc28116c86b64d6e589bcd38"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
+"checksum arrayvec 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "35c1e907260135089def5aac0c66ca42624f2ed60652451812fedbc5a574baed"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
+"checksum bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "32866f4d103c4e438b1db1158aa1b1a80ee078e5d77a59a2f906fd62a577389c"
+"checksum bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72cd7314bd4ee024071241147222c706e80385a1605ac7d4cd2fcc339da2ae46"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
+"checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+"checksum byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96c8b41881888cc08af32d47ac4edd52bc7fa27fef774be47a92443756451304"
 "checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
+"checksum cgl 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8bdd78cca65a739cb5475dbf6b6bbb49373e327f4a6f2b499c0f98632df38c10"
 "checksum cgmath 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0e11c523fa03836a9e3d800ec22ca0584e0450e0d730b65fabc65064993f8797"
 "checksum clap 2.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d480c39a2e5f9b3a3798c661613e1b0e7a7ae71e005102d4aa910fc3289df484"
+"checksum cocoa 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3afe4613f57a171039a98db1773f5840b5743cf85aaf03afb65ddfade4f4a9db"
+"checksum cocoa 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1e1be5fd98bb7e8ef0eea233a4984f4e85ecdcfa002a90b8b12b7a20faf44dc1"
 "checksum color_quant 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a475fc4af42d83d28adf72968d9bcfaf035a1a9381642d8e85d8a04957767b0d"
+"checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
+"checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
+"checksum core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0c56c6022ba22aedbaa7d231be545778becbe1c7aceda4c82ba2f2084dd4c723"
+"checksum core-graphics 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "66e998abb8823fecd2a8a7205429b17a340d447d8c69b3bce86846dcdea3e33b"
 "checksum deflate 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebb02aaf4b775afc96684b8402510a338086974e38570a1f65bea8c202eb77a7"
 "checksum deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1614659040e711785ed8ea24219140654da1729f3ec8a47a9719d041112fe7bf"
+"checksum dlib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "148bce4ce1c36c4509f29cb54e62c2bd265551a9b00b38070fad551a851866ec"
+"checksum draw_state 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1596fcda8b7c1ec84f68d5d09dad7ad01266a1793214d257deb1f6f7d98e8185"
+"checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
+"checksum dwmapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07c4c7cc7b396419bc0a4d90371d0cee16cb5053b53647d287c0b728000c41fe"
 "checksum enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
+"checksum fs2 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bcd414e5a1a979b931bb92f41b7a54106d3f6d2e6c253e9ce943b7cd468251ef"
+"checksum gdi32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "65256ec4dc2592e6f05bfc1ca3b956a4e0698aa90b1dff1f5687d55a5a3fd59a"
+"checksum gfx 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "24667dd5df455d86b0d3ec0a485b0b564ec2231133443750a81dc99cc149eb86"
+"checksum gfx_core 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "701271f73f7cd6088853c41e444d353bd52d139988deddf7374395e4b868da83"
+"checksum gfx_device_gl 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a51227aeddea73fb2bfd17d760f6aee6c7a1adbdc55a5670090b6e6a26af0ce"
+"checksum gfx_gl 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f25c3866329ab91b92bfbc4d5e1d8172607e804564d90b8fbecb96cbc366845d"
 "checksum gif 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8a80d6fe9e52f637df9afd4779449a7be17c39cc9c35b01589bb833f956ba596"
+"checksum gl 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a201d035da99a5c7fabbf4d6b0819f89201498b955d9b73380ebae63bbb5e2f0"
+"checksum gl_generator 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1d8edc81c5ae84605a62f5dac661a2313003b26d59839f81d47d46cf0f16a55"
+"checksum gleam 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9590e0e578d528a080c5abac678e7efbe349a73c7316faafd4073edf5f462d01"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum glutin 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1f95cc9a8363627259b4a25db878eb5b1a159857bc41f525412302fa9de0f12b"
 "checksum image 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "979bad0502082fd60053a490282e87d6c89650942e3a270e0d4c83569c7f5899"
 "checksum inflate 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e7e0062d2dc2f17d2f13750d95316ae8a2ff909af0fda957084f5defd87c43bb"
+"checksum interpolation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "84e53e2877f735534c2d3cdbb5ba1d04ee11107f599a1e811ab0ff3dd93fe66e"
+"checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum jpeg-decoder 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "5c4ff3d14e7ef3522471ab712832c3dd50001f7fb7aa4cdc48af811d63b531e9"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum khronos_api 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "09c9d3760673c427d46f91a0350f0a84a52e6bc5a84adf26dc610b6c52436630"
+"checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "88ee81885f9f04bff991e306fea7c1c60a5f0f9e409e99f6b40e3311a3363135"
+"checksum libloading 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0a020ac941774eb37e9d13d418c37b522e76899bfc4e7b1a600d529a53f83a66"
+"checksum linked-hash-map 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "f26e961e0c884309cd527b1402a5409d35db612b36915d755e1a4f5c1547a31c"
 "checksum linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
+"checksum log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5141eca02775a762cc6cd564d8d2c50f67c0ea3a372cbf1c51592b3e029e10ad"
 "checksum lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084"
+"checksum malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+"checksum memmap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "69253224aa10070855ea8fe9dbe94a03fc2b1d7930bb340c9e586a7513716fea"
+"checksum nodrop 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "52cd74cd09beba596430cc6e3091b74007169a56246e1262f0ba451ea95117b2"
 "checksum num-integer 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "21e4df1098d1d797d27ef0c69c178c3fab64941559b290fcae198e0825c9c8b5"
 "checksum num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d1891bd7b936f12349b7d1403761c8a0b85a18b148e9da4429d5d102c1a41e"
 "checksum num-rational 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "c2dc5ea04020a8f18318ae485c751f8cfa1c0e69dcf465c29ddaaa64a313cc44"
 "checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
 "checksum num_cpus 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a18c392466409c50b87369414a2680c93e739aedeb498eb2bff7d7eb569744e2"
+"checksum objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "877f30f37acef6749b1841cceab289707f211aecfc756553cd63976190e6cc2e"
+"checksum odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "c3df9b730298cea3a1c3faa90b7e2f9df3a9c400d0936d6015e6165734eefcba"
+"checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
+"checksum phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "cb325642290f28ee14d8c6201159949a872f220c62af6e110a56ea914fbe42fc"
+"checksum phf_codegen 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "d62594c0bb54c464f633175d502038177e90309daf2e0158be42ed5f023ce88f"
+"checksum phf_generator 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "6b07ffcc532ccc85e3afc45865469bf5d9e4ef5bfcf9622e3cfe80c2d275ec03"
+"checksum phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "07e24b0ca9643bdecd0632f2b3da6b1b89bbb0030e0b992afc1113b23a7bc2f2"
+"checksum piston 0.31.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8d5530501544c72dff924629d054d8f52f8a0005f7c2bd55a91559c9562735"
+"checksum piston-float 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b058c3a640efd4bcf63266512e4bb03187192c1b29edd38b16d5a014613e3199"
+"checksum piston-gfx_texture 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b43c7f2b785786fb0c19de56c68bcba774c8a9eeb202d889ed0b60b2f96e62e"
+"checksum piston-shaders_graphics2d 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "97bc17dac1dfff3e5cb84116062c7b46ff9d3dc0d88696a46d2f054cf64a10b6"
+"checksum piston-texture 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca39d71646f3b878dd4b0f9758f38d09658b2efd08dbdd9abf9f17000f1b9832"
+"checksum piston-viewport 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c5548a838fd9dc604c96d886c03c303f043a2d85f88719cca59dc7991d86343"
+"checksum piston2d-gfx_graphics 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)" = "979168115843b215398597e6b8ffcb77558ed6bb6a59abc66fe7087c36a39069"
+"checksum piston2d-graphics 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d72cce9e129be5f50f5f26b69a064481664b6eccbdf643139563ea20485419f"
+"checksum piston_window 0.64.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9bf4d1f734e32a4e0ce552bc7ce9a8caaa8f5427cb50b68d84f68c76d31e0ab1"
+"checksum pistoncore-event_loop 0.31.4 (registry+https://github.com/rust-lang/crates.io-index)" = "29e38de35f847d21bc63130f6c9e71f9590e0d11597d5d3f392d9e7c45b89341"
+"checksum pistoncore-glutin_window 0.35.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a0c68a2b3efd7ad36902255f5f4129600bd716d284b595334a2916db5d5f5de4"
+"checksum pistoncore-input 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0cc4654fdf7987f621edc31f21f907aa5bec66376af1a218f63ba62e83febf25"
+"checksum pistoncore-window 0.26.2 (registry+https://github.com/rust-lang/crates.io-index)" = "298f8212a06f164fc65ae2f7bad003acc6aea37efbd64ca5ba068313d122dcc0"
+"checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum png 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3cb773e9a557edb568ce9935cf783e3cdcabe06a9449d41b3e5506d88e582c82"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum rayon 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50c575b58c2b109e2fbc181820cbe177474f35610ff9e357dc75f6bac854ffbf"
+"checksum read_color 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "682bfa200630193df2954f2632b690c4643563fd6abc575edc1239bcfe57ad83"
 "checksum redox_syscall 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "29dbdfd4b9df8ab31dec47c6087b7b13cbf4a776f335e4de8efba8288dda075b"
+"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+"checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
+"checksum rusttype 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c64ffc93b0cc5a6f5e5e84da2a4082b0271e0a1dd76e821bdac570bda7797e"
 "checksum scoped_threadpool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3ef399c8893e8cb7aa9696e895427fab3a6bf265977bb96e126f24ddd2cda85a"
+"checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
+"checksum serde 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1b0e0732aa8ec4267f61815a396a942ba3525062e3bd5520aa8419927cfc0a92"
+"checksum serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 "checksum serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)" = "f023838e7e1878c679322dc7f66c3648bd33763a215fad752f378a623856898d"
 "checksum serde_codegen_internals 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bc888bd283bd2420b16ad0d860e35ad8acb21941180a83a189bb2046f9d00400"
 "checksum serde_derive 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ebb753639f6d55ba1acbcd330ccaf4d9f5862353ac2851e43eac63c2a5343a11"
+"checksum serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ad8bcf487be7d2e15d3d543f04312de991d631cfe1b43ea0ade69e6a8a5b16a1"
 "checksum serde_yaml 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f8bd3f24ad8c7bcd34a6d70ba676dc11302b96f4f166aa5f947762e01098844d"
+"checksum shader_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "476a6f59085a3b8ba2d1127d3f3d9d3b100bbc60301a6a557a405313ea99096f"
+"checksum shared_library 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fb04126b6fcfd2710fb5b6d18f4207b6c535f2850a7e1a43bcd526d44f30a79a"
+"checksum shell32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72f20b8f3c060374edb8046591ba28f62448c369ccbdc7b02075103fb3a9e38d"
+"checksum siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0df90a788073e8d0235a67e50441d47db7c8ad9debd91cbf43736a2a92d36537"
+"checksum stb_truetype 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "21b5c3b588a493a477e0d99769ee091b3627625f9ba4bdd882e6b4b0b0958805"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.10 (registry+https://github.com/rust-lang/crates.io-index)" = "171b739972d9a1bfb169e8077238b51f9ebeaae4ff6e08072f7ba386a8802da2"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum target_build_utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f42dc058080c19c6a58bdd1bf962904ee4f5ef1fe2a81b529f31dacc750c679f"
+"checksum tempfile 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3213fd2b7ed87e39306737ccfac04b1233b57a33ca64cfbf52f2ffaa2b765e2f"
 "checksum term_size 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "07b6c1ac5b3fffd75073276bca1ceed01f67a28537097a2a9539e116e50fb21a"
 "checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
 "checksum unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18127285758f0e2c6cf325bb3f3d138a12fee27de4f23e146cd6a179f26c2cf3"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6717129de5ac253f5642fc78a51d0c7de6f9f53d617fc94e9bae7f6e71cf5504"
 "checksum vec_map 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8cdc8b93bd0198ed872357fb2e667f7125646b1762f16d60b2c96350d361897"
+"checksum vecmath 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bebe25d9d469c3bc85dd86564c7318a0290e31d472d9fcbca682c93e2925ff00"
+"checksum wayland-client 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "a4b2b9876c6c97ece4f1ac699b5172550df443f36942fdcdcc27768c8f1437b4"
+"checksum wayland-kbd 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2b4b69d43d6cce82d95a2c5e81605abd1fa4783bf49d09cd85aa092f16081ef1"
+"checksum wayland-scanner 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "21fd38866b7539ec70300596a905ca838e9f8212aa114fa1cebc13801fbeecff"
+"checksum wayland-sys 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "604257d049da3dc9c49a0bac58f0f09265d838959721da2c41f19db5ca8cc59f"
+"checksum wayland-window 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7595fbe537dee3a380f32104ddfcf2f43db8cb8843031531e1426eb524d1c608"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum winit 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f68c756743f68e5420a93f72c43c9cd8d3b89163692e09a5b53c12caf82386ba"
+"checksum x11-dl 2.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f8f229cb66ab27440d0b8c8e37f8c62e60e169145e084b49795a1a22b62f1e"
+"checksum xml-rs 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7ec6c39eaa68382c8e31e35239402c0a9489d4141a8ceb0c716099a0b515b562"
 "checksum yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.1.0"
 dependencies = [
  "cgmath 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -547,6 +548,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "owning_ref"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "phf"
 version = "0.7.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +764,7 @@ version = "0.1.0"
 dependencies = [
  "clap 2.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston_window 0.64.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "raingun-lib 0.1.0",
  "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -886,6 +918,16 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "smallvec"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "stb_truetype"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,6 +988,15 @@ dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread-id"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1176,6 +1227,9 @@ dependencies = [
 "checksum objc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "877f30f37acef6749b1841cceab289707f211aecfc756553cd63976190e6cc2e"
 "checksum odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "c3df9b730298cea3a1c3faa90b7e2f9df3a9c400d0936d6015e6165734eefcba"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
+"checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
+"checksum parking_lot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aebb68eebde2c99f89592d925288600fde220177e46b5c9a91ca218d245aeedf"
+"checksum parking_lot_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "56a19dcbb5d1e32b6cccb8a9aa1fc2a38418c8699652e735e2bf391a3dc0aa16"
 "checksum phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "cb325642290f28ee14d8c6201159949a872f220c62af6e110a56ea914fbe42fc"
 "checksum phf_codegen 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "d62594c0bb54c464f633175d502038177e90309daf2e0158be42ed5f023ce88f"
 "checksum phf_generator 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "6b07ffcc532ccc85e3afc45865469bf5d9e4ef5bfcf9622e3cfe80c2d275ec03"
@@ -1216,6 +1270,8 @@ dependencies = [
 "checksum shared_library 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fb04126b6fcfd2710fb5b6d18f4207b6c535f2850a7e1a43bcd526d44f30a79a"
 "checksum shell32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72f20b8f3c060374edb8046591ba28f62448c369ccbdc7b02075103fb3a9e38d"
 "checksum siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0df90a788073e8d0235a67e50441d47db7c8ad9debd91cbf43736a2a92d36537"
+"checksum smallvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4f8266519bc1d17d0b5b16f6c21295625d562841c708f6376f49028a43e9c11e"
+"checksum stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
 "checksum stb_truetype 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "21b5c3b588a493a477e0d99769ee091b3627625f9ba4bdd882e6b4b0b0958805"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.10 (registry+https://github.com/rust-lang/crates.io-index)" = "171b739972d9a1bfb169e8077238b51f9ebeaae4ff6e08072f7ba386a8802da2"
@@ -1223,6 +1279,7 @@ dependencies = [
 "checksum target_build_utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f42dc058080c19c6a58bdd1bf962904ee4f5ef1fe2a81b529f31dacc750c679f"
 "checksum tempfile 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3213fd2b7ed87e39306737ccfac04b1233b57a33ca64cfbf52f2ffaa2b765e2f"
 "checksum term_size 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "07b6c1ac5b3fffd75073276bca1ceed01f67a28537097a2a9539e116e50fb21a"
+"checksum thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4437c97558c70d129e40629a5b385b3fb1ffac301e63941335e4d354081ec14a"
 "checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
 "checksum unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18127285758f0e2c6cf325bb3f3d138a12fee27de4f23e146cd6a179f26c2cf3"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["Magnus Bergmark <magnus.bergmark@gmail.com>"]
 raingun-lib = { path = "raingun-lib" }
 clap = "2.23"
 image = "0.12"
+parking_lot = "0.4"
 piston_window = "0.64.0"
 serde = "0.9"
 serde_derive = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["Magnus Bergmark <magnus.bergmark@gmail.com>"]
 raingun-lib = { path = "raingun-lib" }
 clap = "2.23"
 image = "0.12"
+piston_window = "0.64.0"
 serde = "0.9"
 serde_derive = "0.9"
 serde_yaml = "0.6"

--- a/raingun-lib/Cargo.toml
+++ b/raingun-lib/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Magnus Bergmark <magnus.bergmark@gmail.com>"]
 [dependencies]
 cgmath = { version = "0.13", default-features = false, features = ["eders"] }
 image = "0.12"
+parking_lot = "0.4"
 rayon = "0.6"
 serde = "0.9"
 serde_derive = "0.9"

--- a/raingun-lib/src/lib.rs
+++ b/raingun-lib/src/lib.rs
@@ -6,7 +6,6 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
-
 // TODO: Make this an attribute of the scene
 const SHADOW_BIAS: f64 = 1e-13;
 
@@ -14,6 +13,7 @@ mod bodies;
 mod color;
 mod lights;
 mod ray;
+mod rendering;
 mod scene;
 pub mod material;
 
@@ -22,6 +22,7 @@ pub use color::Color;
 pub use lights::{Light, DirectionalLight, SphericalLight};
 pub use ray::Ray;
 pub use scene::Scene;
+pub use rendering::RenderedPixel;
 pub use cgmath::prelude::*;
 
 pub type Point3 = cgmath::Point3<f64>;

--- a/raingun-lib/src/lib.rs
+++ b/raingun-lib/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate cgmath;
 extern crate image;
+extern crate parking_lot;
 extern crate rayon;
 extern crate serde;
 

--- a/raingun-lib/src/rendering.rs
+++ b/raingun-lib/src/rendering.rs
@@ -1,0 +1,209 @@
+use std::sync::mpsc::Sender;
+
+use image::{ImageBuffer, Rgba, Pixel};
+
+use bodies::*;
+use color::Color;
+use material::*;
+use ray::Ray;
+use scene::Scene;
+
+use cgmath::prelude::*;
+use super::{Point3, Vector3};
+
+use super::SHADOW_BIAS;
+
+use std::f32::consts::PI;
+
+pub struct RenderedPixel {
+    pub x: u32,
+    pub y: u32,
+    pub color: Color,
+}
+
+pub fn render_image(scene: &Scene, width: u32, height: u32) -> ImageBuffer<Rgba<u8>, Vec<u8>> {
+    use rayon::prelude::*;
+
+    let raw_colors: Vec<Color> = (0u32..width * height)
+        .into_par_iter()
+        .map(|i| {
+                 let y = i / width;
+                 let x = i - y * width;
+                 render_pixel(scene, x, y, width, height)
+             })
+        .collect();
+
+    let raw_image: Vec<u8> = raw_colors
+        .into_iter()
+        .flat_map(|c| c.rgba().channels().to_owned())
+        .collect();
+    ImageBuffer::from_raw(width, height, raw_image).unwrap()
+}
+
+pub fn render_image_stream(scene: &Scene,
+                           width: u32,
+                           height: u32,
+                           channel_tx: Sender<RenderedPixel>)
+                           -> () {
+    use rayon::prelude::*;
+    use std::sync::{Arc, Mutex};
+
+    let channel = Arc::new(Mutex::new(channel_tx));
+
+    (0u32..width * height)
+        .into_par_iter()
+        // Use .all so we can try to cancel processing if channel is closed.
+        .all(|i| {
+            let y = i / width;
+            let x = i - y * width;
+            let color = render_pixel(scene, x, y, width, height);
+
+            let receipt = channel
+                .lock()
+                .unwrap()
+                .send(RenderedPixel {
+                          x: x,
+                          y: y,
+                          color: color,
+                      });
+
+            receipt.is_ok()
+        });
+}
+
+fn render_pixel(scene: &Scene, x: u32, y: u32, width: u32, height: u32) -> Color {
+    let ray = Ray::create_prime(x, y, scene, width, height);
+    if let Some(intersection) = scene.trace(&ray) {
+        get_color(scene, &ray, &intersection, 0)
+    } else {
+        scene.default_color
+    }
+}
+
+fn get_color(scene: &Scene, ray: &Ray, intersection: &Intersection, depth: u32) -> Color {
+    let hit_point = ray.origin + (ray.direction * intersection.distance);
+    let body = intersection.body;
+    let surface_normal = body.surface_normal(&hit_point);
+    let material = body.material();
+
+    match material.surface {
+        Surface::Diffuse => shade_diffuse(scene, body, &hit_point, &surface_normal),
+        Surface::Reflecting { reflectivity } => {
+            let diffuse_color = shade_diffuse(scene, body, &hit_point, &surface_normal);
+            let reflection_ray = Ray::create_reflection(surface_normal, ray.direction, hit_point);
+            (diffuse_color * (1.0 - reflectivity)) +
+            (cast_ray(scene, &reflection_ray, depth + 1) * reflectivity)
+        }
+        Surface::Refractive {
+            index,
+            transparency,
+        } => {
+            let refraction_color;
+
+            let kr = fresnel(ray.direction, surface_normal, index) as f32;
+            let surface_color = material
+                .coloration
+                .color(&body.texture_coords(&hit_point));
+
+            if kr < 1.0 {
+                let transmission_ray = Ray::create_transmission(surface_normal,
+                                                                ray.direction,
+                                                                hit_point,
+                                                                SHADOW_BIAS,
+                                                                index)
+                        .unwrap();
+                refraction_color = cast_ray(scene, &transmission_ray, depth + 1);
+            } else {
+                refraction_color = scene.default_color;
+            }
+
+            let reflection_ray = Ray::create_reflection(surface_normal, ray.direction, hit_point);
+            let reflection_color = cast_ray(scene, &reflection_ray, depth + 1);
+
+            let mut color = reflection_color * kr + refraction_color * (1.0 - kr);
+            color = color * transparency * surface_color;
+            color
+        }
+    }
+}
+
+fn cast_ray(scene: &Scene, ray: &Ray, depth: u32) -> Color {
+    if depth >= scene.max_recursion_depth {
+        scene.default_color
+    } else {
+        let intersection = scene.trace(&ray);
+        intersection
+            .map(|intersection| get_color(scene, &ray, &intersection, depth))
+            .unwrap_or(scene.default_color)
+    }
+}
+
+fn shade_diffuse(scene: &Scene,
+                 body: &Body,
+                 hit_point: &Point3,
+                 surface_normal: &Vector3)
+                 -> Color {
+    let texture_coords = body.texture_coords(&hit_point);
+    let body_color = body.color(&texture_coords);
+
+    let mut final_color = Color::black();
+    for light in &scene.lights {
+        let direction_to_light = light.direction_from(&hit_point);
+
+        // Calculate shadow by casting a ray from the hit point to the light and see if it's occluded
+        // by a body.
+        // Place origin ever so slightly above the hitpoint to avoid floating point errors where the
+        // origin is inside the body itself, so the ray intersects with itself.
+        let shadow_ray = Ray::new(hit_point + (surface_normal * SHADOW_BIAS),
+                                  direction_to_light);
+        let shadow_intersection = scene.trace(&shadow_ray);
+
+        let in_light = match shadow_intersection {
+            None => true,
+            Some(intersection) => intersection.distance > light.distance(&hit_point),
+        };
+
+        let light_intensity = if in_light {
+            light.intensity(&hit_point)
+        } else {
+            0.0
+        };
+
+        let light_power = (surface_normal.dot(direction_to_light) as f32).max(0.0) *
+                          light_intensity;
+        let light_reflected = body.albedo() / PI;
+        let light_color = light.color() * light_power * light_reflected;
+
+        final_color = final_color + (body_color * light_color);
+    }
+
+    final_color.clamp()
+}
+
+fn fresnel(incident: Vector3, normal: Vector3, index: f32) -> f64 {
+    let i_dot_n = incident.dot(normal);
+    let eta_i;
+    let eta_t;
+
+    if i_dot_n > 0.0 {
+        eta_i = index as f64;
+        eta_t = 1.0;
+    } else {
+        eta_i = 1.0;
+        eta_t = index as f64;
+    }
+
+    let sin_t = eta_i / eta_t * (1.0 - i_dot_n * i_dot_n).max(0.0).sqrt();
+
+    if sin_t > 1.0 {
+        // Total internal reflection
+        return 1.0;
+    } else {
+        let cos_t = (1.0 - sin_t * sin_t).max(0.0).sqrt();
+        let cos_i = cos_t.abs();
+        let r_s = ((eta_t * cos_i) - (eta_i * cos_t)) / ((eta_t * cos_i) + (eta_i * cos_t));
+        let r_p = ((eta_i * cos_i) - (eta_t * cos_t)) / ((eta_i * cos_i) + (eta_t * cos_t));
+
+        return (r_s * r_s + r_p * r_p) / 2.0;
+    }
+}

--- a/raingun-lib/src/rendering.rs
+++ b/raingun-lib/src/rendering.rs
@@ -45,8 +45,9 @@ pub fn render_image_stream(scene: &Scene,
                            height: u32,
                            channel_tx: Sender<RenderedPixel>)
                            -> () {
+    use std::sync::Arc;
+    use parking_lot::Mutex;
     use rayon::prelude::*;
-    use std::sync::{Arc, Mutex};
 
     let channel = Arc::new(Mutex::new(channel_tx));
 
@@ -60,7 +61,6 @@ pub fn render_image_stream(scene: &Scene,
 
             let receipt = channel
                 .lock()
-                .unwrap()
                 .send(RenderedPixel {
                           x: x,
                           y: y,

--- a/raingun-lib/src/scene.rs
+++ b/raingun-lib/src/scene.rs
@@ -1,15 +1,12 @@
 use bodies::*;
 use color::Color;
-use image::{ImageBuffer, Rgba, Pixel};
+use image::{ImageBuffer, Rgba};
 use lights::*;
-use material::*;
 use ray::Ray;
-use cgmath::prelude::*;
-use super::{Point3, Vector3};
+use rendering;
+use rendering::RenderedPixel;
 
-use super::SHADOW_BIAS;
-
-use std::f32::consts::PI;
+use std::sync::mpsc::Sender;
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields, default, rename_all = "camelCase")]
@@ -41,159 +38,15 @@ impl Scene {
             .min_by(|i1, i2| i1.distance.partial_cmp(&i2.distance).unwrap())
     }
 
-    pub fn render(&self, width: u32, height: u32) -> ImageBuffer<Rgba<u8>, Vec<u8>> {
-        use rayon::prelude::*;
-
-        let raw_colors: Vec<Color> = (0u32..width * height)
-            .into_par_iter()
-            .map(|i| {
-                     let y = i / width;
-                     let x = i - y * width;
-                     self.render_pixel(x, y, width, height)
-                 })
-            .collect();
-
-        let raw_image: Vec<u8> = raw_colors
-            .into_iter()
-            .flat_map(|c| c.rgba().channels().to_owned())
-            .collect();
-        ImageBuffer::from_raw(width, height, raw_image).unwrap()
+    pub fn render_image(&self, width: u32, height: u32) -> ImageBuffer<Rgba<u8>, Vec<u8>> {
+        rendering::render_image(self, width, height)
     }
 
-    fn render_pixel(&self, x: u32, y: u32, width: u32, height: u32) -> Color {
-        let ray = Ray::create_prime(x, y, self, width, height);
-        if let Some(intersection) = self.trace(&ray) {
-            get_color(self, &ray, &intersection, 0)
-        } else {
-            self.default_color
-        }
-    }
-}
-
-pub fn get_color(scene: &Scene, ray: &Ray, intersection: &Intersection, depth: u32) -> Color {
-    let hit_point = ray.origin + (ray.direction * intersection.distance);
-    let body = intersection.body;
-    let surface_normal = body.surface_normal(&hit_point);
-    let material = body.material();
-
-    match material.surface {
-        Surface::Diffuse => shade_diffuse(scene, body, &hit_point, &surface_normal),
-        Surface::Reflecting { reflectivity } => {
-            let diffuse_color = shade_diffuse(scene, body, &hit_point, &surface_normal);
-            let reflection_ray = Ray::create_reflection(surface_normal, ray.direction, hit_point);
-            (diffuse_color * (1.0 - reflectivity)) +
-            (cast_ray(scene, &reflection_ray, depth + 1) * reflectivity)
-        }
-        Surface::Refractive {
-            index,
-            transparency,
-        } => {
-            let refraction_color;
-
-            let kr = fresnel(ray.direction, surface_normal, index) as f32;
-            let surface_color = material
-                .coloration
-                .color(&body.texture_coords(&hit_point));
-
-            if kr < 1.0 {
-                let transmission_ray = Ray::create_transmission(surface_normal,
-                                                                ray.direction,
-                                                                hit_point,
-                                                                SHADOW_BIAS,
-                                                                index)
-                        .unwrap();
-                refraction_color = cast_ray(scene, &transmission_ray, depth + 1);
-            } else {
-                refraction_color = scene.default_color;
-            }
-
-            let reflection_ray = Ray::create_reflection(surface_normal, ray.direction, hit_point);
-            let reflection_color = cast_ray(scene, &reflection_ray, depth + 1);
-
-            let mut color = reflection_color * kr + refraction_color * (1.0 - kr);
-            color = color * transparency * surface_color;
-            color
-        }
-    }
-}
-
-fn cast_ray(scene: &Scene, ray: &Ray, depth: u32) -> Color {
-    if depth >= scene.max_recursion_depth {
-        scene.default_color
-    } else {
-        let intersection = scene.trace(&ray);
-        intersection
-            .map(|intersection| get_color(scene, &ray, &intersection, depth))
-            .unwrap_or(scene.default_color)
-    }
-}
-
-fn shade_diffuse(scene: &Scene,
-                 body: &Body,
-                 hit_point: &Point3,
-                 surface_normal: &Vector3)
-                 -> Color {
-    let texture_coords = body.texture_coords(&hit_point);
-    let body_color = body.color(&texture_coords);
-
-    let mut final_color = Color::black();
-    for light in &scene.lights {
-        let direction_to_light = light.direction_from(&hit_point);
-
-        // Calculate shadow by casting a ray from the hit point to the light and see if it's occluded
-        // by a body.
-        // Place origin ever so slightly above the hitpoint to avoid floating point errors where the
-        // origin is inside the body itself, so the ray intersects with itself.
-        let shadow_ray = Ray::new(hit_point + (surface_normal * SHADOW_BIAS),
-                                  direction_to_light);
-        let shadow_intersection = scene.trace(&shadow_ray);
-
-        let in_light = match shadow_intersection {
-            None => true,
-            Some(intersection) => intersection.distance > light.distance(&hit_point),
-        };
-
-        let light_intensity = if in_light {
-            light.intensity(&hit_point)
-        } else {
-            0.0
-        };
-
-        let light_power = (surface_normal.dot(direction_to_light) as f32).max(0.0) *
-                          light_intensity;
-        let light_reflected = body.albedo() / PI;
-        let light_color = light.color() * light_power * light_reflected;
-
-        final_color = final_color + (body_color * light_color);
-    }
-
-    final_color.clamp()
-}
-
-fn fresnel(incident: Vector3, normal: Vector3, index: f32) -> f64 {
-    let i_dot_n = incident.dot(normal);
-    let eta_i;
-    let eta_t;
-
-    if i_dot_n > 0.0 {
-        eta_i = index as f64;
-        eta_t = 1.0;
-    } else {
-        eta_i = 1.0;
-        eta_t = index as f64;
-    }
-
-    let sin_t = eta_i / eta_t * (1.0 - i_dot_n * i_dot_n).max(0.0).sqrt();
-
-    if sin_t > 1.0 {
-        // Total internal reflection
-        return 1.0;
-    } else {
-        let cos_t = (1.0 - sin_t * sin_t).max(0.0).sqrt();
-        let cos_i = cos_t.abs();
-        let r_s = ((eta_t * cos_i) - (eta_i * cos_t)) / ((eta_t * cos_i) + (eta_i * cos_t));
-        let r_p = ((eta_i * cos_i) - (eta_t * cos_t)) / ((eta_i * cos_i) + (eta_t * cos_t));
-
-        return (r_s * r_s + r_p * r_p) / 2.0;
+    pub fn streaming_render(&self,
+                            width: u32,
+                            height: u32,
+                            channel_tx: Sender<RenderedPixel>)
+                            -> () {
+        rendering::render_image_stream(self, width, height, channel_tx)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,21 @@
 use std::path::{Path, PathBuf};
 
-extern crate piston_window;
 extern crate image;
-
+extern crate piston_window;
 extern crate time;
-use time::{PreciseTime, Duration};
 
 #[macro_use]
 extern crate clap;
 use clap::Arg;
 
 extern crate raingun_lib as raingun;
-use raingun::{Scene, RenderedPixel};
+use raingun::Scene;
 
 extern crate serde_yaml;
 use std::fs::File;
+
+mod render;
+use render::*;
 
 fn construct_app<'a, 'b>() -> clap::App<'a, 'b> {
     app_from_crate!()
@@ -65,23 +66,6 @@ fn construct_app<'a, 'b>() -> clap::App<'a, 'b> {
                  .help("The scene definition file, in YAML format."))
 }
 
-
-struct RenderOptions {
-    width: u32,
-    height: u32,
-    max_recursion_depth: Option<u32>,
-}
-
-impl Default for RenderOptions {
-    fn default() -> RenderOptions {
-        RenderOptions {
-            width: 800,
-            height: 600,
-            max_recursion_depth: None,
-        }
-    }
-}
-
 impl<'a, 'b> From<&'b clap::ArgMatches<'a>> for RenderOptions {
     fn from(matches: &clap::ArgMatches<'a>) -> RenderOptions {
         let mut options = RenderOptions::default();
@@ -108,168 +92,6 @@ impl<'a, 'b> From<&'b clap::ArgMatches<'a>> for RenderOptions {
 
         options
     }
-}
-
-/*
-Preview window works with multiple threads:
-    - Render threads (multiple)
-        Renders one pixel at a time of the image.
-
-    - Collector thread (single)
-        Receives rendered pixels on the channel and puts them into an ImageBuffer.
-
-    - Window thread (single)
-        Opens a window and renders the ImageBuffer to it occasionally.
-
-The collected image will be locked using a Mutex and communication from render threads to the
-collector thread uses an async channel with "unlimited buffer". That means that even if the preview
-window has locked the imagebuffer and the collector cannot read the channels, the render threads
-can still send new pixel data to the channel.
-*/
-use std::sync::mpsc::{channel, Receiver};
-use std::sync::{Mutex, Arc, RwLock};
-use std::thread;
-use std::thread::JoinHandle;
-use image::Rgba;
-
-type ImageBuffer = image::ImageBuffer<Rgba<u8>, Vec<u8>>;
-
-fn render_image_without_preview(scene: &Scene,
-                                render_options: &RenderOptions,
-                                input_path: &Path,
-                                output_path: &Path) {
-
-    let render_start = PreciseTime::now();
-    let image = scene.render_image(render_options.width, render_options.height);
-    let render_end = PreciseTime::now();
-
-    image.save(&output_path).expect("Could not encode image");
-
-    let write_end = PreciseTime::now();
-
-    print_render_message(&input_path,
-                         &output_path,
-                         render_start.to(render_end),
-                         render_end.to(write_end));
-}
-
-fn render_image_with_preview(scene: &Scene,
-                             render_options: &RenderOptions,
-                             input_path: &Path,
-                             output_path: &Path) {
-    // Create shared image buffer
-    let shared_image: ImageBuffer = image::ImageBuffer::new(render_options.width,
-                                                            render_options.height);
-    let shared_image = Arc::new(Mutex::new(shared_image));
-
-    // Create render thread channel
-    let (channel_tx, channel_rx) = channel();
-
-    // Create window
-    let close_window_condition = Arc::new(RwLock::new(false));
-    let window_thread = start_window_thread(shared_image.clone(),
-                                            render_options,
-                                            close_window_condition.clone());
-
-    // Start collector thread
-    let collector_thread = start_collector_thread(channel_rx, shared_image.clone());
-
-    // Start rendering threads
-    let render_start = PreciseTime::now();
-    scene.streaming_render(render_options.width, render_options.height, channel_tx);
-    let render_end = PreciseTime::now();
-
-    // When done, close channel
-    //    ...on closed channel, close window and stop collector.
-    // (This happens in the other threads)
-
-    // Store image buffer to output file when everything is done
-    let write_end = {
-        let shared_image = shared_image.lock().expect("Image became corrupted");
-
-        shared_image
-            .save(&output_path)
-            .expect("Could not encode image");
-
-        PreciseTime::now()
-    };
-
-    print_render_message(&input_path,
-                         &output_path,
-                         render_start.to(render_end),
-                         render_end.to(write_end));
-
-    // Exit
-    {
-        let mut close = close_window_condition.write().unwrap();
-        *close = true;
-    }
-    collector_thread.join().unwrap();
-    window_thread.join().unwrap();
-}
-
-fn start_window_thread(shared_image: Arc<Mutex<ImageBuffer>>,
-                       render_options: &RenderOptions,
-                       close_condition: Arc<RwLock<bool>>)
-                       -> JoinHandle<()> {
-    let width = render_options.width;
-    let height = render_options.height;
-
-    thread::spawn(move || {
-        use piston_window::*;
-        let mut window: PistonWindow = WindowSettings::new("Raingun", (width, height))
-            .exit_on_esc(true)
-            .build()
-            .expect("Could not build PistonWindow");
-
-        let mut texture = {
-            let image = shared_image.lock().unwrap();
-            let texture_settings = TextureSettings::new();
-            Texture::from_image(&mut window.factory, &image, &texture_settings).unwrap()
-        };
-
-        while let Some(e) = window.next() {
-            // Don't block until we get a lock; instead just skip this frame update if mutex is busy.
-            if let Ok(image) = shared_image.try_lock() {
-                texture.update(&mut window.encoder, &image).unwrap();
-            }
-
-            window.draw_2d(&e, |context, graphics| {
-                clear([0.0, 0.0, 0.0, 1.0], graphics);
-                image(&texture, context.view, graphics);
-            });
-
-            if *close_condition.read().unwrap() {
-                window.set_should_close(true);
-                break;
-            }
-        }
-    })
-}
-
-fn start_collector_thread(channel_rx: Receiver<RenderedPixel>,
-                          shared_image: Arc<Mutex<ImageBuffer>>)
-                          -> JoinHandle<()> {
-    thread::spawn(move || {
-        // rustfmt has a bug when it formats this while loop. It can be solved by having this
-        // comment here.
-        // See this issue for details: https://github.com/rust-lang-nursery/rustfmt/issues/1467
-        loop {
-            let message = channel_rx.recv();
-            match message {
-                Ok(rendered_pixel) => {
-                    let mut image = shared_image.lock().unwrap();
-                    image.put_pixel(rendered_pixel.x,
-                                    rendered_pixel.y,
-                                    rendered_pixel.color.rgba());
-                }
-                Err(_) => {
-                    // Channel was closed, abort collector loop.
-                    break;
-                }
-            }
-        }
-    })
 }
 
 fn main() {
@@ -305,34 +127,6 @@ fn main() {
         render_image_with_preview(&scene, &render_options, &input_path, &output_path);
     } else {
         render_image_without_preview(&scene, &render_options, &input_path, &output_path);
-    }
-}
-
-fn print_render_message(input_path: &Path,
-                        output_path: &Path,
-                        render_duration: Duration,
-                        write_duration: Duration) {
-    println!("{input}\t→\t{output}\t({render_duration} render, {write_duration} write)",
-             input = input_path.to_string_lossy(),
-             output = output_path.to_string_lossy(),
-             render_duration = format_duration(render_duration),
-             write_duration = format_duration(write_duration));
-}
-
-fn format_duration(duration: Duration) -> String {
-    const ONE_MINUTE: i64 = 1000 * 60;
-
-    let milliseconds = duration.num_milliseconds();
-    match milliseconds {
-        0...800 => format!("{}ms", milliseconds),
-        800...ONE_MINUTE => format!("{:.2}s", milliseconds as f32 / 1000.0),
-        n if n < 0 => unreachable!("Time travel discovered. I'm happy we crashed!"),
-        _ => {
-            let minutes = milliseconds / ONE_MINUTE;
-            let ms_left = milliseconds - minutes * ONE_MINUTE;
-
-            format!("{}m {:.2}s", minutes, ms_left as f32 / 1000.0)
-        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 extern crate image;
+extern crate parking_lot;
 extern crate piston_window;
 extern crate time;
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,212 @@
+/*
+Preview window works with multiple threads:
+    - Render threads (multiple)
+        Renders one pixel at a time of the image.
+
+    - Collector thread (single)
+        Receives rendered pixels on the channel and puts them into an ImageBuffer.
+
+    - Window thread (single)
+        Opens a window and renders the ImageBuffer to it occasionally.
+
+The collected image will be locked using a Mutex and communication from render threads to the
+collector thread uses an async channel with "unlimited buffer". That means that even if the preview
+window has locked the imagebuffer and the collector cannot read the channels, the render threads
+can still send new pixel data to the channel.
+*/
+use std::path::Path;
+use std::sync::mpsc::{channel, Receiver};
+use std::sync::{Mutex, Arc, RwLock};
+use std::thread::JoinHandle;
+use std::thread;
+
+extern crate image;
+use image::Rgba;
+use time::{PreciseTime, Duration};
+
+use raingun::{Scene, RenderedPixel};
+
+pub type ImageBuffer = image::ImageBuffer<Rgba<u8>, Vec<u8>>;
+
+pub struct RenderOptions {
+    pub width: u32,
+    pub height: u32,
+    pub max_recursion_depth: Option<u32>,
+}
+
+impl Default for RenderOptions {
+    fn default() -> RenderOptions {
+        RenderOptions {
+            width: 800,
+            height: 600,
+            max_recursion_depth: None,
+        }
+    }
+}
+
+
+pub fn render_image_without_preview(scene: &Scene,
+                                    render_options: &RenderOptions,
+                                    input_path: &Path,
+                                    output_path: &Path) {
+
+    let render_start = PreciseTime::now();
+    let image = scene.render_image(render_options.width, render_options.height);
+    let render_end = PreciseTime::now();
+
+    image.save(&output_path).expect("Could not encode image");
+
+    let write_end = PreciseTime::now();
+
+    print_render_message(&input_path,
+                         &output_path,
+                         render_start.to(render_end),
+                         render_end.to(write_end));
+}
+
+pub fn render_image_with_preview(scene: &Scene,
+                                 render_options: &RenderOptions,
+                                 input_path: &Path,
+                                 output_path: &Path) {
+    // Create shared image buffer
+    let shared_image: ImageBuffer = image::ImageBuffer::new(render_options.width,
+                                                            render_options.height);
+    let shared_image = Arc::new(Mutex::new(shared_image));
+
+    // Create render thread channel
+    let (channel_tx, channel_rx) = channel();
+
+    // Create window
+    let close_window_condition = Arc::new(RwLock::new(false));
+    let window_thread = start_window_thread(shared_image.clone(),
+                                            render_options,
+                                            close_window_condition.clone());
+
+    // Start collector thread
+    let collector_thread = start_collector_thread(channel_rx, shared_image.clone());
+
+    // Start rendering threads
+    let render_start = PreciseTime::now();
+    scene.streaming_render(render_options.width, render_options.height, channel_tx);
+    let render_end = PreciseTime::now();
+
+    // When done, close channel
+    //    ...on closed channel, close window and stop collector.
+    // (This happens in the other threads)
+
+    // Store image buffer to output file when everything is done
+    let write_end = {
+        let shared_image = shared_image.lock().expect("Image became corrupted");
+
+        shared_image
+            .save(&output_path)
+            .expect("Could not encode image");
+
+        PreciseTime::now()
+    };
+
+    print_render_message(&input_path,
+                         &output_path,
+                         render_start.to(render_end),
+                         render_end.to(write_end));
+
+    // Exit
+    {
+        let mut close = close_window_condition.write().unwrap();
+        *close = true;
+    }
+    collector_thread.join().unwrap();
+    window_thread.join().unwrap();
+}
+
+fn start_window_thread(shared_image: Arc<Mutex<ImageBuffer>>,
+                       render_options: &RenderOptions,
+                       close_condition: Arc<RwLock<bool>>)
+                       -> JoinHandle<()> {
+    let width = render_options.width;
+    let height = render_options.height;
+
+    thread::spawn(move || {
+        use piston_window::*;
+        let mut window: PistonWindow = WindowSettings::new("Raingun", (width, height))
+            .exit_on_esc(true)
+            .build()
+            .expect("Could not build PistonWindow");
+
+        let mut texture = {
+            let image = shared_image.lock().unwrap();
+            let texture_settings = TextureSettings::new();
+            Texture::from_image(&mut window.factory, &image, &texture_settings).unwrap()
+        };
+
+        while let Some(e) = window.next() {
+            // Don't block until we get a lock; instead just skip this frame update if mutex is busy.
+            if let Ok(image) = shared_image.try_lock() {
+                texture.update(&mut window.encoder, &image).unwrap();
+            }
+
+            window.draw_2d(&e, |context, graphics| {
+                clear([0.0, 0.0, 0.0, 1.0], graphics);
+                image(&texture, context.view, graphics);
+            });
+
+            if *close_condition.read().unwrap() {
+                window.set_should_close(true);
+                break;
+            }
+        }
+    })
+}
+
+fn start_collector_thread(channel_rx: Receiver<RenderedPixel>,
+                          shared_image: Arc<Mutex<ImageBuffer>>)
+                          -> JoinHandle<()> {
+    thread::spawn(move || {
+        // rustfmt has a bug when it formats this while loop. It can be solved by having this
+        // comment here.
+        // See this issue for details: https://github.com/rust-lang-nursery/rustfmt/issues/1467
+        loop {
+            let message = channel_rx.recv();
+            match message {
+                Ok(rendered_pixel) => {
+                    let mut image = shared_image.lock().unwrap();
+                    image.put_pixel(rendered_pixel.x,
+                                    rendered_pixel.y,
+                                    rendered_pixel.color.rgba());
+                }
+                Err(_) => {
+                    // Channel was closed, abort collector loop.
+                    break;
+                }
+            }
+        }
+    })
+}
+
+fn print_render_message(input_path: &Path,
+                        output_path: &Path,
+                        render_duration: Duration,
+                        write_duration: Duration) {
+    println!("{input}\t→\t{output}\t({render_duration} render, {write_duration} write)",
+             input = input_path.to_string_lossy(),
+             output = output_path.to_string_lossy(),
+             render_duration = format_duration(render_duration),
+             write_duration = format_duration(write_duration));
+}
+
+fn format_duration(duration: Duration) -> String {
+    const ONE_MINUTE: i64 = 1000 * 60;
+
+    let milliseconds = duration.num_milliseconds();
+    match milliseconds {
+        0...800 => format!("{}ms", milliseconds),
+        800...ONE_MINUTE => format!("{:.2}s", milliseconds as f32 / 1000.0),
+        n if n < 0 => unreachable!("Time travel discovered. I'm happy we crashed!"),
+        _ => {
+            let minutes = milliseconds / ONE_MINUTE;
+            let ms_left = milliseconds - minutes * ONE_MINUTE;
+
+            format!("{}m {:.2}s", minutes, ms_left as f32 / 1000.0)
+        }
+    }
+}

--- a/src/render.rs
+++ b/src/render.rs
@@ -152,14 +152,15 @@ fn start_window_thread(shared_image: Arc<Mutex<ImageBuffer>>,
             Texture::from_image(&mut window.factory, &image, &texture_settings).unwrap()
         };
 
-        let half_width = (width / 2) as f64;
-        let half_height = (height / 2) as f64;
+        let width_f = width as f64;
+        let height_f = height as f64;
+        let half_width = width_f / 2.0;
+        let half_height = height_f / 2.0;
 
         while let Some(event) = window.next() {
             if let Some(_) = event.update_args() {
                 if *close_condition.read() {
                     window.set_should_close(true);
-                    break;
                 }
 
                 let image = shared_image.lock();
@@ -171,10 +172,15 @@ fn start_window_thread(shared_image: Arc<Mutex<ImageBuffer>>,
                     clear([0.0, 0.0, 0.0, 1.0], graphics);
 
                     // Center image inside window
-                    let (x, y) = ((r.width / 2) as f64, (r.height / 2) as f64);
+                    let (center_x, center_y) = ((r.width / 2) as f64, (r.height / 2) as f64);
+
+                    // Resize image to show as much as possible on the screen
+                    let ratio = (r.width as f64 / width_f).min(r.height as f64 / height_f);
+
                     let transform = context
                         .transform
-                        .trans(x, y)
+                        .trans(center_x, center_y)
+                        .scale(ratio, ratio)
                         .trans(-half_width, -half_height);
 
                     image(&texture, transform, graphics);


### PR DESCRIPTION
Adds a preview window![1]

The preview window will show the image as its rendered, which is a nice looking progress. It's currently just closing after render is completed and the process exists normally. For future expansions, I have a lot of ideas.

![Screenshot of preview window, rendering an image that is not yet rendered fully](https://cloud.githubusercontent.com/assets/1599/25309095/cb5a3332-27c3-11e7-9fbb-3184bd02e91c.png)

You can close the window by pressing escape. The rendering will continue in the background unaffected.

* We could separate the normal `raingun` CLI into a second `rainground` (playground) that rerenders automatically when the scene definition changes, among other things.
* We could display a progress bar on the window.
* Window could stay open until explicitly closed.
* Allow cancelling of rendering.

## Architecture

This works by having several threads:

* Main render workers.
* Collector thread.
* Window thread.

These threads communicate using channels and a shared image buffer for the rendered image.

### Render threads

The render threads will, instead of collecting all pixels to a buffer that will later be parsed into an image, push each new pixel to the collector using a channel. The channel supports multiple concurrent writes to it while only supporting a single consumer, which means that little locking issues would bubble up. Pixels can come in any order.

When all pixels have been rendered the channel will be closed.

### Collector thread

The collector thread will listen to the channel and put each pixel to its place in the backing image buffer. This will happen one pixel at a time.

When the channel is closed the collector will tell the window to close and then exit.

### Window thread

The window thread will open a window and start an event loop. Up to 15 times per second it will lock the image buffer and convert a copy of it to a texture, then unlock it again.
It will also, up to 30 times per second, render the current texture to the window centered and scaled for your viewing pleasure.

Before updating, this thread will quickly look and see if the window should be closed and mark it for closing.

### Channels and locks

When the window locks the image to copy it to a texture, the collector will wait for the lock to finish before it can push more pixels. This does not stop rendering, however, as the channel used is buffered. The renderers will continue pushing pixels to the queue and when the lock is released again, the collector will quickly work again to try to catch up.

I have not benchmarked if we have any obvious bottlenecks where things could speed up further, but I have a small suspicion that the close signal could be such a place. It'll be untouched for an eternity and then quickly switched once. I looked at using a `Condvar` instead of a `RwLock<bool>`, but `Condvar` can only wait by blocking (it's the purpose of it after all), so the event loop would just die by that point.

If we spun up yet another thread here with a `Condvar` that has access to the `window` instance, we could block that thread and then just wake up and tell the window to close. But, then we'd have to have a `Mutex` around the Window, probably just making this worse.

We could also check less often, but by now we're entering the territory of premature optimization. I'm still not sure that this is a problem. If this is much slower on some machines, we could start to debug it further.

As it currently stands, I think everything is running fast enough. I'm rendering at 4K just to be able to see things happen in the window before it closes in release mode, for example.

## Other changes

* The `--preview` option has been renamed to `--draft`.
* All of the rendering changes warranted a extraction from `main.rs` into a `render.rs` file.

---

[1]: This was slated for 0.5 and not 0.2, but personal free-time projects tend to move around the schedule depending on what inspires you. I found a nice windowing and rendering crate, so why not just try it right away?